### PR TITLE
fix: Update encrypted email when user email is changed

### DIFF
--- a/server/json_storage.ts
+++ b/server/json_storage.ts
@@ -173,7 +173,14 @@ export class JsonStorage implements IStorage {
   async updateUser(id: number, updates: Partial<User>): Promise<User | undefined> {
     const index = this.users.findIndex(user => user.id === id);
     if (index === -1) return undefined;
-    this.users[index] = { ...this.users[index], ...updates };
+
+    const updatedUser = { ...this.users[index], ...updates };
+
+    if (updates.email) {
+      updatedUser.email_encrypted = this.encrypt(updates.email);
+    }
+
+    this.users[index] = updatedUser;
     this.saveData();
     return this.users[index];
   }


### PR DESCRIPTION
This commit fixes a bug in the `updateUser` function in `server/json_storage.ts` where the `email_encrypted` field was not being updated when a user's email address was changed. This led to a mismatch between the plaintext email and the encrypted email in the stored data.

The `updateUser` function has been modified to check for an `email` field in the updates object. If it exists, the new email is encrypted and stored in the `email_encrypted` field of the user object.